### PR TITLE
Initial Surfer support

### DIFF
--- a/example/.vscode/settings.json
+++ b/example/.vscode/settings.json
@@ -5,9 +5,6 @@
     "rtlDebugger.watchList": [
         {
             "id": "top data"
-        },
-        {
-            "id": "top data"
         }
     ],
     "rtlDebugger.variableOptions": {

--- a/example/.vscode/settings.json
+++ b/example/.vscode/settings.json
@@ -5,6 +5,9 @@
     "rtlDebugger.watchList": [
         {
             "id": "top data"
+        },
+        {
+            "id": "top data"
         }
     ],
     "rtlDebugger.variableOptions": {

--- a/package.json
+++ b/package.json
@@ -328,7 +328,7 @@
         },
         {
           "command": "rtlDebugger.addToWaveform",
-          "when": "view == rtlDebugger.sidebar",
+          "when": "view == rtlDebugger.sidebar && viewItem =~ /variable/",
           "group": "inline"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -175,6 +175,12 @@
         "command": "rtlDebugger.browseWaveforms",
         "category": "RTL Debugger",
         "title": "Browse Waveforms"
+      },
+      {
+        "command": "rtlDebugger.addToWaveform",
+        "category": "RTL Debugger",
+        "title": "Add to Waveform",
+        "icon": "$(keybindings-add)"
       }
     ],
     "viewsContainers": {
@@ -318,6 +324,11 @@
         {
           "command": "rtlDebugger.unWatchVariable",
           "when": "view == rtlDebugger.sidebar && viewItem =~ /inWatchList/",
+          "group": "inline"
+        },
+        {
+          "command": "rtlDebugger.addToWaveform",
+          "when": "view == rtlDebugger.sidebar",
           "group": "inline"
         }
       ],

--- a/src/debug/session.ts
+++ b/src/debug/session.ts
@@ -99,6 +99,7 @@ export class Session {
             onRecv: async (serverPacket) => {},
             onDone: async () => {},
         };
+        this.secondaryLinks.push(secondaryLink)
         return secondaryLink;
     }
 

--- a/src/debug/session.ts
+++ b/src/debug/session.ts
@@ -99,7 +99,7 @@ export class Session {
             onRecv: async (serverPacket) => {},
             onDone: async () => {},
         };
-        this.secondaryLinks.push(secondaryLink)
+        this.secondaryLinks.push(secondaryLink);
         return secondaryLink;
     }
 

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -22,7 +22,9 @@ export class CXXRTLDebugger {
     private statusBarItem: StatusBarItem;
     private terminal: vscode.Terminal | null = null;
     session: Session | null = null;
-    waveformProvider: WaveformProvider | null = null;
+    nextWaveformviewId: number = 0;
+    waveformProviders: Map<string, WaveformProvider> = new Map();
+    lastActiveWaveformTab: string | null = null;
 
     // Session properties.
 

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import { NodeStreamLink } from './cxxrtl/link';
 import { StatusBarItem } from './ui/status';
 import { Session } from './debug/session';
+import { WaveformProvider } from './ui/waveform';
 
 export enum CXXRTLSimulationStatus {
     Paused = 'paused',
@@ -21,6 +22,7 @@ export class CXXRTLDebugger {
     private statusBarItem: StatusBarItem;
     private terminal: vscode.Terminal | null = null;
     session: Session | null = null;
+    waveformProvider: WaveformProvider | null = null;
 
     // Session properties.
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,9 @@ import { WaveformProvider } from './ui/waveform';
 
 export function activate(context: vscode.ExtensionContext) {
     const rtlDebugger = new CXXRTLDebugger();
+    // TODO This is presumably not the right way to do it, but I'll do it like this for
+    // now in order to test the WCP stuff
+    var waveformProvider: WaveformProvider;
 
     console.log('Attached');
 
@@ -77,6 +80,11 @@ export function activate(context: vscode.ExtensionContext) {
         }
     }));
 
+    context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.addToWaveform', (treeItem) => {
+        console.log("Adding to waveform", waveformProvider)
+        waveformProvider.addVariable(treeItem.designation.variable.cxxrtlIdentifier)
+    }));
+
     context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.setRadix.2', (treeItem) =>
         globalVariableOptions.update(treeItem.designation.variable.cxxrtlIdentifier, { radix: 2 })));
     context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.setRadix.8', (treeItem) =>
@@ -104,7 +112,8 @@ export function activate(context: vscode.ExtensionContext) {
                 retainContextWhenHidden: true,
             });
         const bundleRoot = vscode.Uri.joinPath(context.extensionUri, 'out/');
-        context.subscriptions.push(new WaveformProvider(rtlDebugger, webviewPanel, bundleRoot));
+        waveformProvider = new WaveformProvider(rtlDebugger, webviewPanel, bundleRoot)
+        context.subscriptions.push(waveformProvider);
     }));
 
     // For an unknown reason, the `vscode.open` command (which does the exact same thing) ignores the options.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,9 +11,6 @@ import { WaveformProvider } from './ui/waveform';
 
 export function activate(context: vscode.ExtensionContext) {
     const rtlDebugger = new CXXRTLDebugger();
-    // TODO This is presumably not the right way to do it, but I'll do it like this for
-    // now in order to test the WCP stuff
-    var waveformProvider: WaveformProvider;
 
     console.log('Attached');
 
@@ -81,8 +78,9 @@ export function activate(context: vscode.ExtensionContext) {
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.addToWaveform', (treeItem) => {
-        console.log("Adding to waveform", waveformProvider)
-        waveformProvider.addVariable(treeItem.designation.variable.cxxrtlIdentifier)
+        if (rtlDebugger.waveformProvider) {
+            rtlDebugger.waveformProvider.addVariable(treeItem.designation.variable)
+        }
     }));
 
     context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.setRadix.2', (treeItem) =>
@@ -112,8 +110,8 @@ export function activate(context: vscode.ExtensionContext) {
                 retainContextWhenHidden: true,
             });
         const bundleRoot = vscode.Uri.joinPath(context.extensionUri, 'out/');
-        waveformProvider = new WaveformProvider(rtlDebugger, webviewPanel, bundleRoot)
-        context.subscriptions.push(waveformProvider);
+        rtlDebugger.waveformProvider = new WaveformProvider(rtlDebugger, webviewPanel, bundleRoot)
+        context.subscriptions.push(rtlDebugger.waveformProvider);
     }));
 
     // For an unknown reason, the `vscode.open` command (which does the exact same thing) ignores the options.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,8 @@ import { WaveformProvider } from './ui/waveform';
 export function activate(context: vscode.ExtensionContext) {
     const rtlDebugger = new CXXRTLDebugger();
 
+    console.log('Attached');
+
     const sidebarTreeDataProvider = new sidebar.TreeDataProvider(rtlDebugger);
     const sidebarTreeView = vscode.window.createTreeView('rtlDebugger.sidebar', {
         treeDataProvider: sidebarTreeDataProvider
@@ -60,8 +62,8 @@ export function activate(context: vscode.ExtensionContext) {
     }));
     context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.stepBackward', () =>
         rtlDebugger.session!.stepBackward()));
-    context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.stepForward', () =>
-        rtlDebugger.session!.stepForward()));
+    // context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.stepForward', () =>
+    //     rtlDebugger.session!.stepForward()));
     context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.continueForward', () =>
         rtlDebugger.session!.continueForward()));
     context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.goToTime', async () => {
@@ -89,7 +91,10 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.unWatchVariable', (treeItem) =>
         globalWatchList.remove(treeItem.metadata.index)));
 
+
+    console.log('Registering rtlDebugger.browseWaveforms');
     context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.browseWaveforms', () => {
+        console.log('Running browseWaveforms');
         const webviewPanel = vscode.window.createWebviewPanel(
             'rtlDebugger.waveforms',
             'Waveforms', {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -77,7 +77,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.addToWaveform', (treeItem) => {
         if (rtlDebugger.waveformProvider) {
-            rtlDebugger.waveformProvider.addVariable(treeItem.designation.variable)
+            rtlDebugger.waveformProvider.addVariable(treeItem.designation.variable);
         }
     }));
 
@@ -106,7 +106,7 @@ export function activate(context: vscode.ExtensionContext) {
                 retainContextWhenHidden: true,
             });
         const bundleRoot = vscode.Uri.joinPath(context.extensionUri, 'out/');
-        rtlDebugger.waveformProvider = new WaveformProvider(rtlDebugger, webviewPanel, bundleRoot)
+        rtlDebugger.waveformProvider = new WaveformProvider(rtlDebugger, webviewPanel, bundleRoot);
         context.subscriptions.push(rtlDebugger.waveformProvider);
     }));
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,8 +12,6 @@ import { WaveformProvider } from './ui/waveform';
 export function activate(context: vscode.ExtensionContext) {
     const rtlDebugger = new CXXRTLDebugger();
 
-    console.log('Attached');
-
     const sidebarTreeDataProvider = new sidebar.TreeDataProvider(rtlDebugger);
     const sidebarTreeView = vscode.window.createTreeView('rtlDebugger.sidebar', {
         treeDataProvider: sidebarTreeDataProvider
@@ -98,9 +96,7 @@ export function activate(context: vscode.ExtensionContext) {
         globalWatchList.remove(treeItem.metadata.index)));
 
 
-    console.log('Registering rtlDebugger.browseWaveforms');
     context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.browseWaveforms', () => {
-        console.log('Running browseWaveforms');
         const webviewPanel = vscode.window.createWebviewPanel(
             'rtlDebugger.waveforms',
             'Waveforms', {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,8 +62,8 @@ export function activate(context: vscode.ExtensionContext) {
     }));
     context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.stepBackward', () =>
         rtlDebugger.session!.stepBackward()));
-    // context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.stepForward', () =>
-    //     rtlDebugger.session!.stepForward()));
+    context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.stepForward', () =>
+        rtlDebugger.session!.stepForward()));
     context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.continueForward', () =>
         rtlDebugger.session!.continueForward()));
     context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.goToTime', async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -95,7 +95,6 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.unWatchVariable', (treeItem) =>
         globalWatchList.remove(treeItem.metadata.index)));
 
-
     context.subscriptions.push(vscode.commands.registerCommand('rtlDebugger.browseWaveforms', () => {
         const webviewPanel = vscode.window.createWebviewPanel(
             'rtlDebugger.waveforms',

--- a/src/model/variable.ts
+++ b/src/model/variable.ts
@@ -46,7 +46,7 @@ export abstract class Variable {
     }
 
     get wcpIdentifier(): string {
-        return this.fullName.join('.');
+        return this.fullName.join(' ');
     }
 }
 

--- a/src/model/variable.ts
+++ b/src/model/variable.ts
@@ -46,7 +46,7 @@ export abstract class Variable {
     }
 
     get wcpIdentifier(): string {
-        return this.fullName.join(".");
+        return this.fullName.join('.');
     }
 }
 

--- a/src/model/variable.ts
+++ b/src/model/variable.ts
@@ -44,6 +44,10 @@ export abstract class Variable {
     get cxxrtlIdentifier(): string {
         return this.fullName.join(' ');
     }
+
+    get wcpIdentifier(): string {
+        return this.fullName.join(".");
+    }
 }
 
 export class ScalarVariable extends Variable {

--- a/src/surfer/embed.ts
+++ b/src/surfer/embed.ts
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (message.type === 'cxxrtl_scmessage') {
             await libsurfer.on_cxxrtl_sc_message(message.message.inner);
         } else if (message.type === 'wcp_cs_message') {
-            await libsurfer.send_wcp_sc_message(message.message);
+            await libsurfer.handle_wcp_cs_message(message.message);
         } else {
             console.error('[RTL Debugger] [surferEmbed] Unhandled extension to webview message', message);
         }

--- a/src/surfer/embed.ts
+++ b/src/surfer/embed.ts
@@ -65,8 +65,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         await libsurfer.start_wcp();
 
         libsurferInjectMessage('ToggleMenu'); // turn off menu
-        // libsurferInjectMessage('ToggleStatusBar'); // turn off status bar
-        // libsurferInjectMessage('ToggleSidePanel');
+        libsurferInjectMessage('ToggleStatusbar'); // turn off status bar
+        libsurferInjectMessage('ToggleSidePanel');
         libsurferInjectMessage({ SelectTheme: 'dark+' }); // pick VS Code like theme
 
         overlay.style.display = 'none';

--- a/src/surfer/embed.ts
+++ b/src/surfer/embed.ts
@@ -22,7 +22,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const postMessage = <(message: WebviewToExtensionMessage) => void>vscode.postMessage;
     window.addEventListener('message', async (event: MessageEvent<ExtensionToWebviewMessage>) => {
         const message = event.data;
-        if (message.type === 'cxxrtl_scmessage') {
+        if (message.type === 'cxxrtl_sc_message') {
             await libsurfer.on_cxxrtl_sc_message(message.message.inner);
         } else if (message.type === 'wcp_cs_message') {
             await libsurfer.handle_wcp_cs_message(message.message);
@@ -35,7 +35,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         while (true) {
             const message = await libsurfer.cxxrtl_cs_message();
             if (message) {
-                postMessage({type: 'cxxrtl_csmessage', message: new ClientPacketString(message)});
+                postMessage({type: 'cxxrtl_cs_message', message: new ClientPacketString(message)});
             } else {
                 throw Error('Got an undefined message from Surfer. Its client probably disconnected');
             }

--- a/src/surfer/embed.ts
+++ b/src/surfer/embed.ts
@@ -1,7 +1,6 @@
 import libsurferInit, * as libsurfer from 'libsurfer';
 
 import { ClientPacketString, type ExtensionToWebviewMessage, type WebviewToExtensionMessage } from '../ui/waveform';
-import { Packet } from '../cxxrtl/link';
 
 function libsurferInjectMessage(message: any) {
     libsurfer.inject_message(JSON.stringify(message));
@@ -23,26 +22,24 @@ document.addEventListener('DOMContentLoaded', async () => {
     const postMessage = <(message: WebviewToExtensionMessage) => void>vscode.postMessage;
     window.addEventListener('message', async (event: MessageEvent<ExtensionToWebviewMessage>) => {
         const message = event.data;
-        if (message.type == "cxxrtl_scmessage") {
-          console.log("Sending response message to Surfer")
-          await libsurfer.on_cxxrtl_sc_message(message.message.inner)
-        }
-        else {
-          console.error('[RTL Debugger] [surferEmbed] Unhandled extension to webview message', message);
+        if (message.type === 'cxxrtl_scmessage') {
+            console.log("Handing off ", message.message.inner, " to Surfer")
+            await libsurfer.on_cxxrtl_sc_message(message.message.inner);
+        } else {
+            console.error('[RTL Debugger] [surferEmbed] Unhandled extension to webview message', message);
         }
     });
 
     const handle_cs_messages = async () => {
         while (true) {
-            const message = await libsurfer.cxxrtl_cs_message()
+            const message = await libsurfer.cxxrtl_cs_message();
             if (message) {
-              console.log("Posting message from surfer: ", message);
-              postMessage({type: 'cxxrtl_csmessage', message: new ClientPacketString(message)})
+                postMessage({type: 'cxxrtl_csmessage', message: new ClientPacketString(message)});
             } else {
-              throw Error("Got an undefined message from Surfer. Its client probably disconnected")
+                throw Error('Got an undefined message from Surfer. Its client probably disconnected');
             }
         }
-    }
+    };
 
     try {
         await libsurferInit();
@@ -53,8 +50,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         await libsurfer.start_cxxrtl();
 
         libsurferInjectMessage('ToggleMenu'); // turn off menu
-        libsurferInjectMessage('ToggleStatusBar'); // turn off status bar
-        libsurferInjectMessage('ToggleSidePanel');
+        // libsurferInjectMessage('ToggleStatusBar'); // turn off status bar
+        // libsurferInjectMessage('ToggleSidePanel');
         libsurferInjectMessage({ SelectTheme: 'dark+' }); // pick VS Code like theme
 
         overlay.style.display = 'none';

--- a/src/surfer/embed.ts
+++ b/src/surfer/embed.ts
@@ -46,7 +46,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         while (true) {
             const message = await libsurfer.next_wcp_sc_message();
             if (message) {
-                console.log("[WCP] Receiving wcp sc message: {message}")
                 postMessage({type: 'wcp_sc_message', message: message});
             } else {
                 throw Error('Got an undefined message from Surfer. Its client probably disconnected');

--- a/src/ui/sidebar.ts
+++ b/src/ui/sidebar.ts
@@ -203,10 +203,10 @@ class ScopeTreeItem extends TreeItem {
         for (const variable of variables) {
             if (variable instanceof ScalarVariable) {
                 children.push(new ScalarTreeItem(this.provider, variable.designation(),
-                    variable.width > 1 ? 'canWatch|canSetRadix' : 'canWatch'));
+                    variable.width > 1 ? 'canWatch|canSetRadix|variable' : 'canWatch|variable'));
             }
             if (variable instanceof MemoryVariable) {
-                children.push(new ArrayTreeItem(this.provider, variable.designation(), 'canWatch|canSetRadix'));
+                children.push(new ArrayTreeItem(this.provider, variable.designation(), 'canWatch|canSetRadix|variable'));
             }
         }
         return children;

--- a/src/ui/waveform.ts
+++ b/src/ui/waveform.ts
@@ -15,17 +15,17 @@ export class ServerPacketString {
 
 
 export type ExtensionToWebviewMessage =
-  | { type: 'restore', state: any }
-  // TODO: Proper type here
-  | { type: 'cxxrtl_scmessage', message: ServerPacketString }
-  ;
+    | { type: 'restore', state: any }
+    // TODO: Proper type here
+    | { type: 'cxxrtl_scmessage', message: ServerPacketString }
+    ;
 
 export type WebviewToExtensionMessage =
-  | { type: 'ready' }
-  | { type: 'crash', error: any }
-  // TODO: Proper type here
-  | { type: 'cxxrtl_csmessage', message: ClientPacketString }
-  ;
+    | { type: 'ready' }
+    | { type: 'crash', error: any }
+    // TODO: Proper type here
+    | { type: 'cxxrtl_csmessage', message: ClientPacketString }
+    ;
 
 export class WaveformProvider {
     constructor(
@@ -43,6 +43,7 @@ export class WaveformProvider {
         if (debuggerLink) {
             this.debuggerLink = debuggerLink;
             this.debuggerLink.onRecv = async (message) => {
+                console.log("Receving scmessage ", message.asString());
                 // console.log("Running on recv for ", message)
                 await this.sendMessage({ type: "cxxrtl_scmessage", message: new ServerPacketString(message.asString()) })
             };

--- a/src/ui/waveform.ts
+++ b/src/ui/waveform.ts
@@ -46,9 +46,8 @@ export class WaveformProvider {
         if (debuggerLink) {
             this.debuggerLink = debuggerLink;
             this.debuggerLink.onRecv = async (message) => {
-                console.log("Receving scmessage ", message.asString());
                 // console.log("Running on recv for ", message)
-                await this.sendMessage({ type: "cxxrtl_scmessage", message: new ServerPacketString(message.asString()) })
+                await this.sendMessage({ type: 'cxxrtl_scmessage', message: new ServerPacketString(message.asString()) });
             };
         } else {
             throw new Error('Failed to create secondary debugger link');
@@ -75,11 +74,11 @@ export class WaveformProvider {
             console.log('[RTL Debugger] [WaveformProvider] Ready');
         } else if (message.type === 'crash') {
             console.log('[RTL Debugger] [WaveformProvider] Crash:', message.error);
-        } else if (message.type == 'cxxrtl_csmessage') {
+        } else if (message.type === 'cxxrtl_csmessage') {
             console.log('[RTL Debugger] [WaveformProvider] Got CSMessage', message.message);
             const packet: Packet<ClientPacket> = Packet.fromString(message.message.inner);
             await this.debuggerLink.send(packet);
-        } else if (message.type == 'wcp_sc_message') {
+        } else if (message.type === 'wcp_sc_message') {
             console.log('[RTL Debugger] [WaveformProvider] Got WCP SC message', message.message);
         } else {
             console.error('[RTL Debugger] [WaveformProvider] Unhandled webview to extension message:', message);
@@ -89,11 +88,11 @@ export class WaveformProvider {
     async addVariable(variable: Variable) {
         // TODO: How should we handle the callbacks here?
         const message = JSON.stringify({
-            type: "command",
-            command: "add_variables",
+            type: 'command',
+            command: 'add_variables',
             names: [variable.wcpIdentifier]
-        })
-        this.sendMessage({type: 'wcp_cs_message', message})
+        });
+        this.sendMessage({type: 'wcp_cs_message', message});
     }
 
     private debuggerLink: ILink;

--- a/src/ui/waveform.ts
+++ b/src/ui/waveform.ts
@@ -5,6 +5,7 @@ import { CXXRTLDebugger } from '../debugger';
 import embedHtml from '../surfer/embed.html';
 import { ILink, Packet } from '../cxxrtl/link';
 import { ClientPacket } from '../cxxrtl/proto';
+import { Variable } from '../model/variable';
 
 export class ClientPacketString {
     constructor(public inner: string) { }
@@ -83,6 +84,16 @@ export class WaveformProvider {
         } else {
             console.error('[RTL Debugger] [WaveformProvider] Unhandled webview to extension message:', message);
         }
+    }
+
+    async addVariable(variable: Variable) {
+        // TODO: How should we handle the callbacks here?
+        const message = JSON.stringify({
+            type: "command",
+            command: "add_variables",
+            names: [variable.wcpIdentifier]
+        })
+        this.sendMessage({type: 'wcp_cs_message', message})
     }
 
     private debuggerLink: ILink;

--- a/src/ui/waveform.ts
+++ b/src/ui/waveform.ts
@@ -16,19 +16,19 @@ export class ServerPacketString {
 
 
 export type ExtensionToWebviewMessage =
-    | { type: 'restore', state: any }
-    // TODO: Proper type here
-    | { type: 'cxxrtl_scmessage', message: ServerPacketString }
-    | { type: 'wcp_cs_message', message: string }
-    ;
+| { type: 'restore', state: any }
+// TODO: Proper type here
+| { type: 'cxxrtl_scmessage', message: ServerPacketString }
+| { type: 'wcp_cs_message', message: string }
+;
 
 export type WebviewToExtensionMessage =
-    | { type: 'ready' }
-    | { type: 'crash', error: any }
-    // TODO: Proper type here
-    | { type: 'cxxrtl_csmessage', message: ClientPacketString }
-    | { type: 'wcp_sc_message', message: string }
-    ;
+| { type: 'ready' }
+| { type: 'crash', error: any }
+// TODO: Proper type here
+| { type: 'cxxrtl_csmessage', message: ClientPacketString }
+| { type: 'wcp_sc_message', message: string }
+;
 
 export class WaveformProvider {
     constructor(

--- a/src/ui/waveform.ts
+++ b/src/ui/waveform.ts
@@ -18,7 +18,7 @@ export class ServerPacketString {
 export type ExtensionToWebviewMessage =
 | { type: 'restore', state: any }
 // TODO: Proper type here
-| { type: 'cxxrtl_scmessage', message: ServerPacketString }
+| { type: 'cxxrtl_sc_message', message: ServerPacketString }
 | { type: 'wcp_cs_message', message: string }
 ;
 
@@ -26,7 +26,7 @@ export type WebviewToExtensionMessage =
 | { type: 'ready' }
 | { type: 'crash', error: any }
 // TODO: Proper type here
-| { type: 'cxxrtl_csmessage', message: ClientPacketString }
+| { type: 'cxxrtl_cs_message', message: ClientPacketString }
 | { type: 'wcp_sc_message', message: string }
 ;
 
@@ -47,7 +47,7 @@ export class WaveformProvider {
             this.debuggerLink = debuggerLink;
             this.debuggerLink.onRecv = async (message) => {
                 // console.log("Running on recv for ", message)
-                await this.sendMessage({ type: 'cxxrtl_scmessage', message: new ServerPacketString(message.asString()) });
+                await this.sendMessage({ type: 'cxxrtl_sc_message', message: new ServerPacketString(message.asString()) });
             };
         } else {
             throw new Error('Failed to create secondary debugger link');
@@ -74,7 +74,7 @@ export class WaveformProvider {
             console.log('[RTL Debugger] [WaveformProvider] Ready');
         } else if (message.type === 'crash') {
             console.log('[RTL Debugger] [WaveformProvider] Crash:', message.error);
-        } else if (message.type === 'cxxrtl_csmessage') {
+        } else if (message.type === 'cxxrtl_cs_message') {
             console.log('[RTL Debugger] [WaveformProvider] Got CSMessage', message.message);
             const packet: Packet<ClientPacket> = Packet.fromString(message.message.inner);
             await this.debuggerLink.send(packet);

--- a/src/ui/waveform.ts
+++ b/src/ui/waveform.ts
@@ -18,6 +18,7 @@ export type ExtensionToWebviewMessage =
     | { type: 'restore', state: any }
     // TODO: Proper type here
     | { type: 'cxxrtl_scmessage', message: ServerPacketString }
+    | { type: 'wcp_cs_message', message: string }
     ;
 
 export type WebviewToExtensionMessage =
@@ -25,6 +26,7 @@ export type WebviewToExtensionMessage =
     | { type: 'crash', error: any }
     // TODO: Proper type here
     | { type: 'cxxrtl_csmessage', message: ClientPacketString }
+    | { type: 'wcp_sc_message', message: string }
     ;
 
 export class WaveformProvider {
@@ -76,6 +78,8 @@ export class WaveformProvider {
             console.log('[RTL Debugger] [WaveformProvider] Got CSMessage', message.message);
             const packet: Packet<ClientPacket> = Packet.fromString(message.message.inner);
             await this.debuggerLink.send(packet);
+        } else if (message.type == 'wcp_sc_message') {
+            console.log('[RTL Debugger] [WaveformProvider] Got WCP SC message', message.message);
         } else {
             console.error('[RTL Debugger] [WaveformProvider] Unhandled webview to extension message:', message);
         }

--- a/src/ui/waveform.ts
+++ b/src/ui/waveform.ts
@@ -3,50 +3,83 @@ import * as vscode from 'vscode';
 import { CXXRTLDebugger } from '../debugger';
 // @ts-ignore
 import embedHtml from '../surfer/embed.html';
+import { ILink, Packet } from '../cxxrtl/link';
+import { ClientPacket, ServerPacket } from '../cxxrtl/proto';
+
+export class ClientPacketString {
+  constructor(public inner: string) { }
+}
+export class ServerPacketString {
+  constructor(public inner: string) { }
+}
+
 
 export type ExtensionToWebviewMessage =
-| { type: 'restore', state: any }
-;
+  | { type: 'restore', state: any }
+  // TODO: Proper type here
+  | { type: 'cxxrtl_scmessage', message: ServerPacketString }
+  ;
 
 export type WebviewToExtensionMessage =
-| { type: 'ready' }
-| { type: 'crash', error: any }
-;
+  | { type: 'ready' }
+  | { type: 'crash', error: any }
+  // TODO: Proper type here
+  | { type: 'cxxrtl_csmessage', message: ClientPacketString }
+  ;
 
 export class WaveformProvider {
-    constructor(
-        private rtlDebugger: CXXRTLDebugger,
-        private webviewPanel: vscode.WebviewPanel,
-        bundleRoot: vscode.Uri,
-    ) {
-        const webviewHtml = embedHtml.replace(/__base_href__/,
-            this.webview.asWebviewUri(bundleRoot).toString());
-        this.webview.onDidReceiveMessage(this.processMessage.bind(this));
-        this.webview.html = webviewHtml;
-    }
+  constructor(
+    private rtlDebugger: CXXRTLDebugger,
+    private webviewPanel: vscode.WebviewPanel,
+    bundleRoot: vscode.Uri,
+  ) {
+    const webviewHtml = embedHtml.replace(/__base_href__/,
+      this.webview.asWebviewUri(bundleRoot).toString());
+    this.webview.onDidReceiveMessage(this.processMessage.bind(this));
+    this.webview.html = webviewHtml;
+    const debuggerLink = rtlDebugger.session?.createSecondaryLink()
 
-    dispose() {
-        this.webviewPanel.dispose();
+    // TODO: Correct way to handle errors?
+    if (debuggerLink) {
+      this.debuggerLink = debuggerLink
+      this.debuggerLink.onRecv = async (message) => {
+        console.log("Running on recv for ", message)
+        // await this.sendMessage({ type: "cxxrtl_scmessage", message: new ServerPacketString(message.asString()) })
+      }
+    } else {
+      throw new Error("Failed to create secondary debugger link")
     }
+  }
 
-    get webview() {
-        return this.webviewPanel.webview;
-    }
+  dispose() {
+    this.webviewPanel.dispose();
+  }
 
-    private async sendMessage(message: ExtensionToWebviewMessage) {
-        const messagePosted = await this.webview.postMessage(message);
-        if (!messagePosted) {
-            console.warn('[RTL Debugger] [WaveformProvider] Dropping extension to webview message:', message);
-        }
-    }
+  get webview() {
+    return this.webviewPanel.webview;
+  }
 
-    private async processMessage(message: WebviewToExtensionMessage) {
-        if (message.type === 'ready') {
-            console.log('[RTL Debugger] [WaveformProvider] Ready');
-        } else if (message.type === 'crash') {
-            console.log('[RTL Debugger] [WaveformProvider] Crash:', message.error);
-        } else {
-            console.error('[RTL Debugger] [WaveformProvider] Unhandled webview to extension message:', message);
-        }
+  private async sendMessage(message: ExtensionToWebviewMessage) {
+    const messagePosted = await this.webview.postMessage(message);
+    if (!messagePosted) {
+      console.warn('[RTL Debugger] [WaveformProvider] Dropping extension to webview message:', message);
     }
+  }
+
+  private async processMessage(message: WebviewToExtensionMessage) {
+    if (message.type === 'ready') {
+      console.log('[RTL Debugger] [WaveformProvider] Ready');
+    } else if (message.type === 'crash') {
+      console.log('[RTL Debugger] [WaveformProvider] Crash:', message.error);
+    } else if (message.type == 'cxxrtl_csmessage') {
+      console.log(`[RTL Debugger] [WaveformProvider] Got CSMessage`, message.message);
+      const packet: Packet<ClientPacket> = Packet.fromString(message.message.inner);
+      console.log("Handing ", packet.asString(), " off to debugger link")
+      await this.debuggerLink.send(packet)
+    } else {
+      console.error('[RTL Debugger] [WaveformProvider] Unhandled webview to extension message:', message);
+    }
+  }
+
+  private debuggerLink: ILink;
 }


### PR DESCRIPTION
This adds initial support for viewing waveforms from the debugger in Surfer. For now, it is only possible to open Surfer via the command prompt (`Browse waveforms`). Most of the changes are on the Surfer side, not here, the changes here are primarily to embed surfer, and forward WCP and CXXRTL messages back and forth. There are some UI changes, in particular, a button to add signals to the waveform view.

This should be seen as a proof of concept rather than a fully featured implementation. For now, the CXXRTL implementation on the Surfer side is mature and pretty well tested. The interaction between Surfer and the CXXRTL server via the extension also seems to work flawlessly.

There is less interaction between Surfer and the extension than I'd like. For example, there is no rendering of assertions (though that would be easy to add), and while we discussed having the Surfer time cursor synchronized between Surfer and the extension to show "correct" values in the VSC sidebar, that is something that I have not had time to implement (or know how to do on the extension side). That said, the WCP that we use for bidirectional control of and from the Surfer interface appears to work quite well, and does support the use case.

There are also some small UI papercuts remaining. The user can still use surfer keybinds to (accidentally(?)) open surfer sidebar and menus which in the extension are intended to be the VSCode native sidebar of the debugger. There is also a non-native sidebar for signal values in surfer, but removing and replacing it with a native sidebar would be quite a lot of work. 

There is also no synchronization of signal value translation between surfer and the extension. For example, if you set the radix of a signal in the extension, that choice will not be reflected in Surfer and vice versa. Surfer also has a much more capable translation system which means that just synchronizing them isn't an option.

In addition to these papercuts, there are a few big picture things that probably need resolution before this can be more than a proof of concept:

## Memories are unsupported

This is largely a Surfer side issue as it hasn't had a way to group related signals together. At the moment, adding a memory causes Surfer to crash since it sends an invalid request to the CXXRTL debugger. This is something I can address, but supporting memories requires a bit more work. There are some relevant Surfer issues here https://gitlab.com/surfer-project/surfer/-/issues/353 and https://gitlab.com/surfer-project/surfer/-/issues/97. There is also a UX/performance issue when adding very large memories.

The CXXRTL protocol is relatively slow, so sending full memory content when the user is only interested in some cells is not a particularly good idea. Being able to add individual memory cells might work for now.

## Aliasing

In order to maintain speed, Surfer renders signals by binary searching for the signal value at each pixel. This results in `O(log(n))` lookup which is needed for reasonable performance on long simulation traces. However, this causes aliasing (in the signal theory sense, not the graphics sense)

For example: at one zoom level a clock signal looks like this
![image](https://github.com/user-attachments/assets/93bce3f3-ea70-47c9-a64a-20dc3bb34eff)
but zoomed in one more step, it goes back to its _correct_ value
![image](https://github.com/user-attachments/assets/67b3e593-263e-4a0a-8fa2-5566f5f08d9b)

In file based formats, this is solved by the fact that we have a list of time steps at which a signal changed, so we can check if it changed between two adjacent pixels, even if the value is the same at both pixels.

However, with the cxxrtl protocol, we get the timestamps at which _any_ signal changed, which means that we can't figure out if there is a transition between two pixels without a linear search across all the time steps.

There may be some solutions to this that we _could_ apply, for example we could walk the signal values _once_ when we receive them and build a new structure, but that would require initial work when signals change.

As far as I understand, the server is in theory able to do this anti-aliasing (mipmaping) much more efficiently, and it could be integrated into the protocol as an additional parameter to the `query_interval` command. 


## Performance

In the current implementation, Surfer fetches signals for the whole simulation time range. This is needed because we want to show _something_ when the user is zoomed out, and Surfer can already efficiently render signals with many time steps by binary searching for the correct value (kind of, see the aliasing note above). However, the CXXRTL protocol is quite slow, so fetching signals for long simulation (tens of thousands of samples) makes things noticeably slow, while even longer simulations make the program appear frozen. Again, this is something I cannot do anything about from the surfer side. Mipmaping on the server would solve the issue as it'd only send values for specific time steps that Surfer asks for.

Another option might be to strategically `query_interval` only for the values at which Surfer intends to render signals. However, this would result in a lot of traffic (one JSON request per pixel), and would require quite significant changes to the way queries are handled. 

As a workaround which @robtaylor asked for is to only render the last N samples. The problem with that is that it is not possible for Surfer to know the sample rate (and it can only request time ranges), and as I understand it, the sample rate is not well defined on the server side (not well known for well behaved single clock domain projects, undefined for others). For now, I have made a change to Surfer that assumes a 1us sample rate, and requests 10k samples. This should work as a POC as long as users ensure that they obey that sample rate. If however, they use another sample rate like 1_ns as is done in the example in this repo, the traces will still be too long and it will appear as if the program is frozen for long running simulations.